### PR TITLE
feat(clawgui-eval): add Kimi K2.5 evaluation support

### DIFF
--- a/clawgui-eval/README.md
+++ b/clawgui-eval/README.md
@@ -39,7 +39,7 @@
 **Key Features:**
 - **Dual backend support** — Local GPU via `transformers` or remote API via OpenAI-compatible endpoints
 - **6 benchmarks** — ScreenSpot-Pro, ScreenSpot-V2, UIVision, MMBench-GUI, OSWorld-G, AndroidControl
-- **11+ models** — Qwen3-VL, Qwen2.5-VL, UI-TARS, MAI-UI, GUI-G2, UI-Venus, Gemini, Seed 1.8, and more
+- **12+ models** — Qwen3-VL, Qwen2.5-VL, UI-TARS, MAI-UI, GUI-G2, UI-Venus, Gemini, Seed 1.8, Kimi K2.5, and more
 - **Multi-GPU & multi-thread** — `NUM_GPUS` processes launched via Python `multiprocessing`, each pinned to one GPU via `CUDA_VISIBLE_DEVICES`. Shard files are automatically split and merged; interrupted runs resume from the last completed shard.
 - **Easily extensible** — Add new models by inheriting a simple base class; shared architectures (e.g. UI-TARS extends Qwen2.5-VL) reuse parent model loading and only override prompt building and output parsing
 - **Faithful reproduction** — Comprehensive reproduction results with detailed official vs. reproduced comparisons ([see details](#-reproduction-results))
@@ -172,7 +172,8 @@ clawgui-eval/
 │   ├── uivenus15_inferencer.py          # UI-Venus 1.5 (extends Qwen3-VL)
 │   ├── uivenus_inferencer.py            # UI-Venus (extends GUI-G2)
 │   ├── gemini_inferencer.py             # Gemini (API, optional Zoom)
-│   └── seed_inferencer.py               # Seed 1.8 (API, optional Zoom)
+│   ├── seed_inferencer.py               # Seed 1.8 (API, optional Zoom)
+│   └── kimi_inferencer.py               # Kimi K2.5 (API, optional Zoom)
 ├── 📂 judge/                            # Judgment module
 │   ├── base_judge.py                    # Abstract base class
 │   ├── grounding_judge.py               # Point-in-box judge (most benchmarks)
@@ -224,6 +225,7 @@ clawgui-eval/
 | `uivenus` | UI-Venus | Extends GUI-G2 | `[0, 1000]` | `vt` | ❌ None | ✅ | ✅ | ✅ | ✅ | ✅ | - |
 | `gemini` | Gemini 3.x Pro | API (optional Zoom) | `[0, 1000]` | `tv` | ✅ Built-in | ✅ | - | - | - | - | - |
 | `seed` | Seed 1.8 | API (optional Zoom) | `[0, 1000]` | `tv` | ✅ Built-in | ✅ | - | - | - | - | - |
+| `kimi` | Kimi K2.5 | API (optional Zoom) | `[0, 1000]` | `tv` | ✅ Built-in | ✅ | ✅ | ✅ | ✅ | ✅ | - |
 
 ### Frontier / Closed-Source Models
 
@@ -325,6 +327,9 @@ bash scripts/infer/vllm_depoly/vllm_serve.sh
 
 # 2. Run inference
 bash scripts/infer/api/qwen3vl_run_api.sh
+
+# Kimi K2.5 API
+bash scripts/infer/api/kimi_run_api.sh
 ```
 
 Output is saved to:
@@ -467,6 +472,7 @@ A key goal of ClawGUI-Eval is **faithful reproduction** of officially reported n
 | Gemini 3.0 Pro (Zoom, API) | 72.70 | **75.08** ✅ | - | - | - | - | - | - | - | - |
 | Gemini 3.1 Pro (Zoom, API) | - | **85.01** | - | - | - | - | - | - | - | - |
 | Seed 1.8 (Zoom, API) | 73.10 | **72.80** ✅ | - | - | - | - | - | - | - | - |
+| Kimi K2.5 (API) | - | - | - | - | - | - | - | - | - | - |
 
 **Open-Source GUI Grounding Reproduction Rate:** 44 / 46 cells with official baselines = **95.7%**
 

--- a/clawgui-eval/inference/__init__.py
+++ b/clawgui-eval/inference/__init__.py
@@ -12,6 +12,7 @@ from .guig2_inferencer import GUIG2Inferencer
 from .uivenus_inferencer import UIVenusInferencer
 from .seed_inferencer import SeedInferencer
 from .gemini_inferencer import GeminiInferencer
+from .kimi_inferencer import KimiInferencer
 
 
 INFERENCER_REGISTRY = {
@@ -26,6 +27,7 @@ INFERENCER_REGISTRY = {
     "uivenus"   : UIVenusInferencer,
     "seed"      : SeedInferencer,
     "gemini"    : GeminiInferencer,
+    "kimi"      : KimiInferencer,
 }
 
 
@@ -67,6 +69,7 @@ __all__ = [
     "UIVenusInferencer",
     "SeedInferencer",
     "GeminiInferencer",
+    "KimiInferencer",
     "INFERENCER_REGISTRY",
     "get_inferencer",
 ]

--- a/clawgui-eval/inference/kimi_inferencer.py
+++ b/clawgui-eval/inference/kimi_inferencer.py
@@ -1,0 +1,361 @@
+"""
+Kimi K2.5 Inferencer (API-only).
+
+Model characteristics:
+- Coordinate system: [0, 1000] normalized
+- Output format: (x, y)
+- Uses a fixed system prompt
+- Supports optional Zoom-In (two-stage crop-then-ground)
+
+Zoom-In process:
+  1. Stage 1: Model grounds on the original image
+  2. Stage 2: Crop a region centered on the Stage-1 prediction
+     (default 25% of width/height), resize to 1920×1080, then ground again
+  3. Map Stage-2 relative coordinates back to original image space
+"""
+
+import re
+import base64
+import time
+import random
+from io import BytesIO
+from PIL import Image
+from typing import Any, Optional, Tuple
+from .base_inferencer import BaseInferencer
+
+
+# Retry configuration
+MAX_RETRIES = 8
+RETRY_BASE_DELAY = 2
+RATE_LIMIT_WAIT = 30
+
+# Default Zoom-In configuration
+DEFAULT_CROP_RATIO = 0.25
+ZOOM_RESIZE_W = 1920
+ZOOM_RESIZE_H = 1080
+
+# System prompt
+KIMI_SYSTEM_PROMPT = """You are an expert UI element locator. Given a GUI image and a user's element description, provide your reasoning process first, finally provide the coordinates of the specified element as a single point. For elements with area, return the center point.
+
+Give your reasoning process first, then output the coordinate pair ranging from 0 to 1000 exactly in format:
+(x,y)"""
+
+
+def _pil_to_base64(image: Image.Image) -> str:
+    """Convert a PIL Image to a base64-encoded PNG string."""
+    buf = BytesIO()
+    image.save(buf, format="PNG")
+    return base64.b64encode(buf.getvalue()).decode("utf-8")
+
+
+def _parse_coord(text: str) -> Optional[Tuple[float, float]]:
+    """
+    Parse (x,y) coordinates (0-1000 range) from a model response string.
+    Returns (x, y) on success, or None if parsing fails.
+    """
+    # Method 1: match (x,y) or (x, y) format
+    pattern = r'\(\s*(\d+(?:\.\d+)?)\s*,\s*(\d+(?:\.\d+)?)\s*\)'
+    matches = re.findall(pattern, text)
+    if matches:
+        x, y = matches[-1]
+        return (float(x), float(y))
+
+    # Method 2: match bare x,y format without parentheses
+    pattern2 = r'(\d+(?:\.\d+)?)\s*,\s*(\d+(?:\.\d+)?)'
+    matches2 = re.findall(pattern2, text)
+    if matches2:
+        x, y = matches2[-1]
+        return (float(x), float(y))
+
+    return None
+
+
+def _crop_and_zoom(
+    image: Image.Image,
+    center_x: float,
+    center_y: float,
+    crop_ratio: float = DEFAULT_CROP_RATIO,
+    resize_to: Optional[Tuple[int, int]] = (ZOOM_RESIZE_W, ZOOM_RESIZE_H),
+) -> Tuple[Image.Image, dict]:
+    """
+    Crop around (center_x, center_y) which are in [0, 1000] coordinates.
+
+    Args:
+        image: Original PIL Image.
+        center_x, center_y: Predicted point in [0, 1000].
+        crop_ratio: Fraction of width/height to keep.
+        resize_to: Target size after cropping (None to skip resize).
+
+    Returns:
+        (cropped_image, crop_info) where crop_info is used for coordinate mapping.
+    """
+    w, h = image.size
+    cx = center_x / 1000.0 * w
+    cy = center_y / 1000.0 * h
+    cw = w * crop_ratio
+    ch = h * crop_ratio
+
+    left = cx - cw / 2
+    top = cy - ch / 2
+    right = cx + cw / 2
+    bottom = cy + ch / 2
+
+    # Clamp to image bounds (shift if needed to preserve crop size)
+    if left < 0:
+        right -= left; left = 0
+    if top < 0:
+        bottom -= top; top = 0
+    if right > w:
+        left -= (right - w); right = w
+    if bottom > h:
+        top -= (bottom - h); bottom = h
+    left = max(0, left)
+    top = max(0, top)
+    right = min(w, right)
+    bottom = min(h, bottom)
+
+    cropped = image.crop((int(left), int(top), int(right), int(bottom)))
+    crop_info = {
+        "left": left, "top": top, "right": right, "bottom": bottom,
+        "crop_width": right - left, "crop_height": bottom - top,
+        "orig_width": w, "orig_height": h,
+    }
+    if resize_to is not None:
+        cropped = cropped.resize(resize_to, Image.Resampling.LANCZOS)
+        crop_info["resized_to"] = list(resize_to)
+    return cropped, crop_info
+
+
+def _map_zoomed_to_original(zx: float, zy: float, info: dict) -> Tuple[float, float]:
+    """Map [0,1000] coords in the crop back to [0,1000] coords in the original image."""
+    px = zx / 1000.0 * info["crop_width"] + info["left"]
+    py = zy / 1000.0 * info["crop_height"] + info["top"]
+    ox = max(0, min(1000, px / info["orig_width"] * 1000.0))
+    oy = max(0, min(1000, py / info["orig_height"] * 1000.0))
+    return ox, oy
+
+
+class KimiInferencer(BaseInferencer):
+    """
+    Kimi K2.5 inferencer (API-only, with optional Zoom-In).
+    """
+
+    def __init__(self, model_path: str, backend: str = "api", **kwargs):
+        if backend != "api":
+            raise ValueError(f"KimiInferencer only supports 'api' backend, got '{backend}'")
+        super().__init__(model_path, backend, **kwargs)
+
+    def _init_model(self):
+        """Initialize OpenAI-compatible API client."""
+        from openai import OpenAI
+
+        self.api_key = self.kwargs.get("api_key", "EMPTY")
+        if not self.api_key or self.api_key.strip() == "":
+            self.api_key = "EMPTY"
+
+        api_base_str = self.kwargs.get("api_base", None)
+        if api_base_str is None:
+            raise ValueError("--api_base is required for Kimi API backend.")
+
+        self.api_urls = [u.strip() for u in api_base_str.split(",") if u.strip()]
+        self.model_name = self.kwargs.get("model_name", "kimi-k2-5")
+
+        # Zoom config
+        self.zoom_enabled = self.kwargs.get("zoom", False)
+        self.crop_ratio = DEFAULT_CROP_RATIO
+        self.resize_to = (ZOOM_RESIZE_W, ZOOM_RESIZE_H)
+
+        self.temperature = self.kwargs.get("temperature", 0.0)
+        self.max_tokens = self.kwargs.get("max_tokens", 32768)
+
+        print(f"Loading Kimi model (API): {self.model_name}")
+        print(f"  API endpoints ({len(self.api_urls)}):")
+        for i, url in enumerate(self.api_urls):
+            print(f"    [{i+1}] {url}")
+        print(f"  Zoom: {'enabled (crop_ratio={}, resize={}x{})'.format(self.crop_ratio, ZOOM_RESIZE_W, ZOOM_RESIZE_H) if self.zoom_enabled else 'disabled'}")
+        print(f"  Temperature: {self.temperature}")
+        print(f"  Max Tokens: {self.max_tokens}")
+
+        self.clients = []
+        for url in self.api_urls:
+            self.clients.append(OpenAI(
+                api_key=self.api_key,
+                base_url=url,
+            ))
+        print(f"  {len(self.clients)} API client(s) ready")
+
+    def _build_prompt(self, question: str, image: Image.Image, system_prompts: list = None) -> Any:
+        """Build Kimi API messages (fixed system prompt, image-last by default)."""
+        img_b64 = _pil_to_base64(image)
+        img_url = f"data:image/png;base64,{img_b64}"
+
+        # Kimi K2.5 typically uses vt (image first) or tv (text first) depending on tuning.
+        # We default to image-last (tv) like Gemini/Seed since frontier models often prefer it,
+        # but allow override via tv_or_vt kwarg.
+        tv_or_vt = self.kwargs.get("tv_or_vt", "tv")
+
+        if tv_or_vt == "vt":
+            messages = [
+                {"role": "system", "content": KIMI_SYSTEM_PROMPT},
+                {"role": "user", "content": [
+                    {"type": "image_url", "image_url": {"url": img_url}},
+                    {"type": "text", "text": f"The user's element description is: {question}"},
+                ]},
+            ]
+        else:
+            messages = [
+                {"role": "system", "content": KIMI_SYSTEM_PROMPT},
+                {"role": "user", "content": [
+                    {"type": "text", "text": f"The user's element description is: {question}"},
+                    {"type": "image_url", "image_url": {"url": img_url}},
+                ]},
+            ]
+        return messages
+
+    def _call_api(self, messages: list) -> Optional[str]:
+        """Call API with retries and rate-limit handling. Returns content or None."""
+        last_err = None
+        for attempt in range(MAX_RETRIES):
+            try:
+                client = random.choice(self.clients)
+                resp = client.chat.completions.create(
+                    model=self.model_name,
+                    messages=messages,
+                    max_completion_tokens=self.max_tokens,
+                    temperature=self.temperature,
+                )
+                return resp.choices[0].message.content.strip()
+            except Exception as e:
+                last_err = e
+                err_s = str(e)
+                if "429" in err_s or "rate limit" in err_s.lower():
+                    wait = RATE_LIMIT_WAIT + RETRY_BASE_DELAY ** attempt
+                    print(f"[Attempt {attempt+1}/{MAX_RETRIES}] Rate limit, waiting {wait:.0f}s ...")
+                    time.sleep(wait)
+                else:
+                    print(f"[Attempt {attempt+1}/{MAX_RETRIES}] API error: {type(e).__name__}: {e}")
+                    if attempt < MAX_RETRIES - 1:
+                        time.sleep(RETRY_BASE_DELAY ** attempt)
+        print(f"All {MAX_RETRIES} attempts failed. Last error: {last_err}")
+        return None
+
+    def _generate(self, inputs: Any) -> str:
+        """Single-stage API call (no zoom). Returns raw content string."""
+        content = self._call_api(inputs)
+        return content if content is not None else ""
+
+    def _post_process(self, output) -> str:
+        if isinstance(output, str):
+            return output.strip()
+        return output
+
+    # ------------------------------------------------------------------
+    # Override infer_single to support two-stage Zoom-In
+    # ------------------------------------------------------------------
+    def infer_single(self, sample: dict) -> dict:
+        start_time = time.time()
+        sample_id = sample.get("id", "unknown")
+        image_path = sample.get("image")
+        question = sample.get("question", "")
+
+        if not image_path:
+            return self._error_result(sample_id, "image path is empty", start_time)
+
+        try:
+            image = Image.open(image_path).convert("RGB")
+        except Exception as e:
+            return self._error_result(sample_id, f"image load failed: {e}", start_time)
+
+        # ---- Stage 1: ground on original image ----
+        msgs1 = self._build_prompt(question, image)
+        content1 = self._call_api(msgs1)
+        if content1 is None:
+            return self._error_result(sample_id, "API error in stage 1", start_time)
+
+        # If zoom is disabled or stage-1 parse fails, return stage-1 result directly
+        coord1 = _parse_coord(content1)
+        if not self.zoom_enabled or coord1 is None:
+            return {
+                "id": sample_id,
+                "model_type": self.model_type,
+                "model_response": content1,
+                "prediction": content1,
+                "inference_time": time.time() - start_time,
+            }
+
+        # ---- Stage 2: crop around stage-1 prediction, ground again ----
+        s1x, s1y = coord1
+        cropped, crop_info = _crop_and_zoom(image, s1x, s1y, self.crop_ratio, self.resize_to)
+        msgs2 = self._build_prompt(question, cropped)
+        content2 = self._call_api(msgs2)
+
+        # Fallback to stage-1 if stage-2 fails
+        if content2 is None:
+            return {
+                "id": sample_id,
+                "model_type": self.model_type,
+                "model_response": content1,
+                "prediction": content1,
+                "inference_time": time.time() - start_time,
+                "zoom_info": {
+                    "zoom_enabled": True,
+                    "stage1_coord": [s1x, s1y],
+                    "stage2_api_failed": True,
+                    "fallback": "stage1",
+                },
+            }
+
+        coord2 = _parse_coord(content2)
+        if coord2 is None:
+            return {
+                "id": sample_id,
+                "model_type": self.model_type,
+                "model_response": content1,
+                "prediction": content1,
+                "inference_time": time.time() - start_time,
+                "zoom_info": {
+                    "zoom_enabled": True,
+                    "stage1_coord": [s1x, s1y],
+                    "stage2_parse_failed": True,
+                    "stage2_raw": content2,
+                    "fallback": "stage1",
+                },
+            }
+
+        # Map stage-2 coords back to original image
+        fx, fy = _map_zoomed_to_original(coord2[0], coord2[1], crop_info)
+        final_response = f"({int(round(fx))}, {int(round(fy))})"
+
+        return {
+            "id": sample_id,
+            "model_type": self.model_type,
+            "model_response": final_response,
+            "prediction": final_response,
+            "inference_time": time.time() - start_time,
+            "zoom_info": {
+                "zoom_enabled": True,
+                "crop_ratio": self.crop_ratio,
+                "zoom_resize": list(self.resize_to),
+                "stage1_coord": [s1x, s1y],
+                "stage1_raw": content1,
+                "crop_info": {
+                    "left": crop_info["left"],
+                    "top": crop_info["top"],
+                    "crop_width": crop_info["crop_width"],
+                    "crop_height": crop_info["crop_height"],
+                },
+                "stage2_coord": [coord2[0], coord2[1]],
+                "stage2_raw": content2,
+                "final_coord": [fx, fy],
+            },
+        }
+
+    def _error_result(self, sample_id, msg, start_time):
+        return {
+            "id": sample_id,
+            "model_type": self.model_type,
+            "model_response": "",
+            "prediction": "",
+            "inference_time": time.time() - start_time,
+            "error": msg,
+        }

--- a/clawgui-eval/judge/grounding_judge.py
+++ b/clawgui-eval/judge/grounding_judge.py
@@ -303,6 +303,37 @@ def seed18_parse(infer_str: str, image_size: List[int]) -> Optional[Tuple[float,
     return (abs_x, abs_y)
 
 
+def kimi_parse(infer_str: str, image_size: List[int]) -> Optional[Tuple[float, float]]:
+    """
+    Parse Kimi K2.5 output into absolute pixel coordinates.
+
+    Output format: (x, y) or bare x, y
+    Coordinates are [0, 1000]-normalized.
+    """
+    if not infer_str:
+        return None
+
+    # Method 1: match (x,y) or (x, y) format
+    pattern = r'\(\s*(\d+(?:\.\d+)?)\s*,\s*(\d+(?:\.\d+)?)\s*\)'
+    matches = re.findall(pattern, infer_str)
+    if matches:
+        x, y = matches[-1]
+        coords = [float(x), float(y)]
+        width, height = image_size
+        return (coords[0] / 1000.0 * width, coords[1] / 1000.0 * height)
+
+    # Method 2: match bare x,y format without parentheses
+    pattern2 = r'(\d+(?:\.\d+)?)\s*,\s*(\d+(?:\.\d+)?)'
+    matches2 = re.findall(pattern2, infer_str)
+    if matches2:
+        x, y = matches2[-1]
+        coords = [float(x), float(y)]
+        width, height = image_size
+        return (coords[0] / 1000.0 * width, coords[1] / 1000.0 * height)
+
+    return None
+
+
 def maiui_parse(infer_str: str, image_size: List[int]) -> Optional[Tuple[float, float]]:
     """
     Parse MAI-UI output into absolute pixel coordinates.
@@ -385,8 +416,10 @@ class ScreenSpotJudge(BaseJudge):
                     return maiui_parse(value, image_size)
                 elif model_type == 'seed':
                     return seed18_parse(value, image_size)
+                elif model_type == 'kimi':
+                    return kimi_parse(value, image_size)
                 else:
-                    supported = ['qwen3vl', 'guiowl15', 'qwen25vl', 'guig2', 'uivenus', 'uitars', 'stepgui', 'uivenus15', 'maiui', 'seed']
+                    supported = ['qwen3vl', 'guiowl15', 'qwen25vl', 'guig2', 'uivenus', 'uitars', 'stepgui', 'uivenus15', 'maiui', 'seed', 'kimi']
                     raise ValueError(f"Unsupported model_type: '{model_type}'. Supported: {supported}")
         return None
 

--- a/clawgui-eval/judge/osworld_g_judge.py
+++ b/clawgui-eval/judge/osworld_g_judge.py
@@ -21,6 +21,7 @@ from tqdm import tqdm
 from base_judge import BaseJudge
 from grounding_judge import guig2_parse as _grounding_guig2_parse
 from grounding_judge import seed18_parse as _grounding_seed18_parse
+from grounding_judge import kimi_parse as _grounding_kimi_parse
 
 REFUSAL = (-1, -1)  # sentinel for model refusal output
 
@@ -209,6 +210,15 @@ def seed18_parse(infer_str: str, image_size: List[int]) -> Optional[Tuple[float,
     return _grounding_seed18_parse(infer_str, image_size)
 
 
+def kimi_parse(infer_str: str, image_size: List[int]) -> Optional[Tuple[float, float]]:
+    """Kimi K2.5: [0,1000] (x,y), with refusal check."""
+    if not infer_str:
+        return None
+    if _is_refusal_output(infer_str):
+        return REFUSAL
+    return _grounding_kimi_parse(infer_str, image_size)
+
+
 # ---------- geometry helpers ----------
 
 def is_point_in_rectangle(point: Tuple[float, float], rect: List[float]) -> bool:
@@ -265,8 +275,10 @@ class OSWorldGJudge(BaseJudge):
                     return guig2_parse(value, image_size)
                 elif model_type == 'seed':
                     return seed18_parse(value, image_size)
+                elif model_type == 'kimi':
+                    return kimi_parse(value, image_size)
                 else:
-                    supported = ['qwen3vl', 'guiowl15', 'qwen25vl', 'guig2', 'uivenus', 'uitars', 'stepgui', 'uivenus15', 'maiui', 'seed']
+                    supported = ['qwen3vl', 'guiowl15', 'qwen25vl', 'guig2', 'uivenus', 'uitars', 'stepgui', 'uivenus15', 'maiui', 'seed', 'kimi']
                     raise ValueError(f"Unsupported model_type: '{model_type}'. Supported: {supported}")
         return None
 

--- a/clawgui-eval/main.py
+++ b/clawgui-eval/main.py
@@ -33,6 +33,7 @@ from inference import get_inferencer
 BENCHMARK_DATA_MAP = {
     # screenspot-v2
     "screenspot-v2"           : "data/screenspot-v2.json",
+    "screenspot-v2-kimi"      : "data/screenspot-v2.json",
     "screenspot-v2-qwen3vl"   : "data/screenspot-v2-qwen3vl.json",
     "screenspot-v2-qwen25vl"  : "data/screenspot-v2-qwen25vl.json",
     "screenspot-v2-uitars"    : "data/screenspot-v2-uitars.json",
@@ -45,6 +46,7 @@ BENCHMARK_DATA_MAP = {
     # screenspot-pro
     "screenspot-pro"          : "data/screenspot-pro.json",
     "screenspot-pro-seed"     : "data/screenspot-pro.json",
+    "screenspot-pro-kimi"     : "data/screenspot-pro.json",
     "screenspot-pro-qwen3vl"  : "data/screenspot-pro-qwen3vl.json",
     "screenspot-pro-qwen25vl" : "data/screenspot-pro-qwen25vl.json",
     "screenspot-pro-uitars"   : "data/screenspot-pro-uitars.json",
@@ -56,6 +58,7 @@ BENCHMARK_DATA_MAP = {
     "screenspot-pro-uivenus"  : "data/screenspot-pro-guig2.json",
     # uivision
     "uivision"                : "data/uivision.json",
+    "uivision-kimi"           : "data/uivision.json",
     "uivision-qwen3vl"        : "data/uivision-qwen3vl.json",
     "uivision-qwen25vl"       : "data/uivision-qwen25vl.json",
     "uivision-uitars"         : "data/uivision-uitars.json",
@@ -67,6 +70,7 @@ BENCHMARK_DATA_MAP = {
     "uivision-uivenus"        : "data/uivision-guig2.json",
     # osworld-g
     "osworld-g"               : "data/osworld-g.json",
+    "osworld-g-kimi"          : "data/osworld-g.json",
     "osworld-g-qwen3vl"       : "data/osworld-g-qwen3vl.json",
     "osworld-g-qwen25vl"      : "data/osworld-g-qwen25vl.json",
     "osworld-g-uitars"        : "data/osworld-g-uitars.json",
@@ -78,6 +82,7 @@ BENCHMARK_DATA_MAP = {
     "osworld-g-uivenus"       : "data/osworld-g-guig2.json",
     # mmbench-gui
     "mmbench-gui"             : "data/mmbench-gui.json",
+    "mmbench-gui-kimi"        : "data/mmbench-gui.json",
     "mmbench-gui-qwen3vl"     : "data/mmbench-gui-qwen3vl.json",
     "mmbench-gui-qwen25vl"    : "data/mmbench-gui-qwen25vl.json",
     "mmbench-gui-uitars"      : "data/mmbench-gui-uitars.json",

--- a/clawgui-eval/scripts/infer/api/kimi_run_api.sh
+++ b/clawgui-eval/scripts/infer/api/kimi_run_api.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# ======================
+# Experiment Configuration
+# ======================
+EXPERIMENT_NAME="kimi-k2-5-exp"
+
+
+# ======================
+# API Configuration
+# ======================
+BACKEND="api"
+API_BASE="https://api.moonshot.cn/v1"
+API_KEY=""                    # set your Kimi API key here
+MODEL_NAME="kimi-k2-5"        # or other Kimi vision model name
+
+# ======================
+# Threading Configuration
+# ======================
+NUM_THREADS=16  # number of concurrent threads for API calls
+
+# ======================
+# Zoom Configuration
+# ======================
+# --zoom enables two-stage Zoom-In grounding (default: disabled)
+# crop ratio is 0.25 and resize to 1920x1080 in the inferencer
+ZOOM_FLAG=""
+# ZOOM_FLAG="--zoom"
+
+# ======================
+# Other Configuration
+# ======================
+# screenspot-pro | screenspot-v2 | uivision | mmbench-gui | osworld-g
+BENCHMARK="screenspot-pro"
+
+# ======================
+# Run Inference
+# ======================
+python main.py \
+    --experiment_name ${EXPERIMENT_NAME} \
+    --model_type kimi \
+    --model_path dummy \
+    --backend ${BACKEND} \
+    --api_base ${API_BASE} \
+    --api_key "${API_KEY}" \
+    --model_name "${MODEL_NAME}" \
+    --benchmark ${BENCHMARK}-kimi \
+    --num_threads ${NUM_THREADS} \
+    ${ZOOM_FLAG} \
+    --resume \
+    --verbose

--- a/clawgui-eval/scripts/judge/mmbench-gui_run_judge.sh
+++ b/clawgui-eval/scripts/judge/mmbench-gui_run_judge.sh
@@ -7,7 +7,7 @@ EXP_NAME="uivenus-exp"
 # ======================
 # Model Configuration
 # ======================
-# options: maiui qwen3vl qwen25vl uitars stepgui uivenus uivenus15 guiowl15 guig2
+# options: maiui qwen3vl qwen25vl uitars stepgui uivenus uivenus15 guiowl15 guig2 seed gemini kimi
 MODEL_TYPE="uivenus"
 
 # ======================

--- a/clawgui-eval/scripts/judge/osworld-g_run_judge.sh
+++ b/clawgui-eval/scripts/judge/osworld-g_run_judge.sh
@@ -7,7 +7,7 @@ EXP_NAME="guiowl15-8b-exp"
 # ======================
 # Model Configuration
 # ======================
-# options: maiui qwen3vl qwen25vl uitars stepgui uivenus uivenus15 guiowl15 guig2
+# options: maiui qwen3vl qwen25vl uitars stepgui uivenus uivenus15 guiowl15 guig2 seed gemini kimi
 MODEL_TYPE="guiowl15"
 
 # Whether to include refusal samples in the accuracy denominator.

--- a/clawgui-eval/scripts/judge/screenspot-pro_run_judge.sh
+++ b/clawgui-eval/scripts/judge/screenspot-pro_run_judge.sh
@@ -7,7 +7,7 @@ EXP_NAME="guig2-exp"
 # ======================
 # Model Configuration
 # ======================
-# options: maiui qwen3vl qwen25vl uitars stepgui uivenus uivenus15 guiowl15 guig2 seed
+# options: maiui qwen3vl qwen25vl uitars stepgui uivenus uivenus15 guiowl15 guig2 seed gemini kimi
 MODEL_TYPE="guig2"
 
 # ======================

--- a/clawgui-eval/scripts/judge/screenspot-v2_run_judge.sh
+++ b/clawgui-eval/scripts/judge/screenspot-v2_run_judge.sh
@@ -7,7 +7,7 @@ EXP_NAME="uivenus-exp"
 # ======================
 # Model Configuration
 # ======================
-# options: maiui qwen3vl qwen25vl uitars stepgui uivenus uivenus15 guiowl15 guig2
+# options: maiui qwen3vl qwen25vl uitars stepgui uivenus uivenus15 guiowl15 guig2 seed gemini kimi
 MODEL_TYPE="uivenus"
 
 # ======================

--- a/clawgui-eval/scripts/judge/uivision_run_judge.sh
+++ b/clawgui-eval/scripts/judge/uivision_run_judge.sh
@@ -7,7 +7,7 @@ EXP_NAME="uivenus-exp"
 # ======================
 # Model Configuration
 # ======================
-# options: maiui qwen3vl qwen25vl uitars stepgui uivenus uivenus15 guiowl15 guig2
+# options: maiui qwen3vl qwen25vl uitars stepgui uivenus uivenus15 guiowl15 guig2 seed gemini kimi
 MODEL_TYPE="uivenus"
 
 # ======================


### PR DESCRIPTION
## Summary

This PR adds evaluation support for **Kimi K2.5** (API-only) to `clawgui-eval`, including optional Zoom-In two-stage grounding.

## Changes

- **New inferencer** (`inference/kimi_inferencer.py`)
  - OpenAI-compatible API backend with retry & rate-limit handling
  - Optional Zoom-In (crop 25% + resize to 1920×1080) aligned with the Gemini/Seed frontier-model paradigm
  - Coordinate system: `[0, 1000]` normalized; output format `(x,y)`

- **Registry & data mappings**
  - Registered `kimi` model key in `inference/__init__.py`
  - Added `-kimi` benchmark mappings in `main.py` for:
    - `screenspot-pro`, `screenspot-v2`, `uivision`, `osworld-g`, `mmbench-gui`

- **Judge parsers**
  - Added `kimi_parse` in `judge/grounding_judge.py`
  - Added `kimi_parse` + refusal handling in `judge/osworld_g_judge.py`

- **Scripts & docs**
  - Added `scripts/infer/api/kimi_run_api.sh`
  - Updated judge script comments to include `kimi`
  - Updated `README.md` model table, architecture diagram list, and quick-start examples

## Testing

- All modified files pass `python -m py_compile` syntax checks.
- No existing model logic or evaluation pipelines were changed.

## Notes

- Kimi K2.5 does not yet have publicly reported baselines on these static GUI-grounding benchmarks, so this addition enables the first standardized evaluation for the model in this suite.
