### PR TITLE
fix: handle reasoning_content in streaming for reasoning models

### DIFF
--- a/clawgui-agent/phone_agent/model/client.py
+++ b/clawgui-agent/phone_agent/model/client.py
@@ -88,8 +88,24 @@ class ModelClient:
         for chunk in stream:
             if len(chunk.choices) == 0:
                 continue
-            if chunk.choices[0].delta.content is not None:
-                content = chunk.choices[0].delta.content
+
+            # Handle reasoning_content (for reasoning models like MAI-UI-2B)
+            reasoning_content = getattr(chunk.choices[0].delta, 'reasoning_content', None)
+            if reasoning_content is not None:
+                raw_content += reasoning_content
+
+                # Record time to first token
+                if not first_token_received:
+                    time_to_first_token = time.time() - start_time
+                    first_token_received = True
+
+                if not in_action_phase:
+                    # Print reasoning content as it arrives (thinking phase)
+                    print(reasoning_content, end="", flush=True)
+
+            # Handle regular content
+            content = getattr(chunk.choices[0].delta, 'content', None)
+            if content is not None:
                 raw_content += content
 
                 # Record time to first token


### PR DESCRIPTION
## Fix: reasoning_content streaming support for MAI-UI models

### Problem
MAI-UI series reasoning models (like ClawGUI-2B) send thinking content via `delta.reasoning_content` instead of `delta.content`. This caused the WebUI 'AI思考过程' display to show empty.

### Solution
Modified `client.py` to handle both `reasoning_content` and `content` fields during streaming:



### Testing
Run with MAI-UI model type selected and verify thinking process displays correctly.

### Modules Affected
- `clawgui-agent`

### Checklist
- [x] Code follows existing style
- [ ] Tested locally (pending hardware)
- [x] Bug fix

Fixes: https://github.com/ZJU-REAL/ClawGUI/issues/2