### PR TITLE
docs(clawgui-rl): rename OpenGUI-Server → ClawGUI-Server and surface --mount-src-path

### DIFF
--- a/clawgui-rl/README.md
+++ b/clawgui-rl/README.md
@@ -104,7 +104,7 @@ ClawGUI-RL supports two training modes: **virtual environment scaling** (via Doc
 
 ### 1. Virtual Environment Scaling
 
-#### Step 1 — Clone OpenGUI-Server
+#### Step 1 — Clone ClawGUI-Server
 
 ```bash
 git clone https://github.com/sugarandgugu/ClawGUI-Server
@@ -115,8 +115,10 @@ git clone https://github.com/sugarandgugu/ClawGUI-Server
 Follow the installation guide in the ClawGUI-Server repository. Key steps include:
 
 1. **Verify KVM support** — Ensure your machine supports KVM virtualization (`kvm-ok` or check `/dev/kvm`).
-2. **Pull the Docker image** — Pull the MobileWorld Android emulator image as described in the OpenGUI-Server docs.
+2. **Pull the Docker image** — Pull the MobileWorld Android emulator image as described in the ClawGUI-Server docs.
 3. **Launch Docker containers** — Start one or more containers. Each running container exposes a backend URL (e.g., `http://127.0.0.1:PORT`).
+
+> **Tip:** To run containers against the latest upstream [MobileWorld](https://github.com/Tongyi-MAI/MobileWorld) source without rebuilding the Docker image, pass `--mount-src-path /path/to/MobileWorld/src` to `mw env run`. See the ClawGUI-Server README for details.
 
 After this step, each container provides an API backend URL that ClawGUI-RL will use to interact with the emulated phone.
 
@@ -220,9 +222,9 @@ Real-device training is a notoriously challenging problem in the industry. It in
 
 #### Step 1 — Prepare your Android device
 
-If you have already cloned OpenGUI-Server, connect a physical Android phone to your computer via USB.
+If you have already cloned ClawGUI-Server, connect a physical Android phone to your computer via USB.
 
-> **Running on a remote server?** If your training runs on a remote server but you want to connect a local phone via USB, you can set up port forwarding between your local machine and the server. For detailed steps, refer to the real-device training section in the OpenGUI-Server documentation.
+> **Running on a remote server?** If your training runs on a remote server but you want to connect a local phone via USB, you can set up port forwarding between your local machine and the server. For detailed steps, refer to the real-device training section in the ClawGUI-Server documentation.
 
 #### Step 2 — Enable developer mode & USB debugging
 
@@ -247,7 +249,7 @@ uv run mobile-world server
 
 #### Step 5 — Test device connectivity
 
-Use the OpenGUI-Server test script to verify that your device is recognized:
+Use the ClawGUI-Server test script to verify that your device is recognized:
 
 ```bash
 python test_true_device.py
@@ -257,7 +259,7 @@ Make sure the correct `device_id` is set (check with `adb devices`).
 
 #### Step 6 — Register device backend URL
 
-Fill the OpenGUI-Server API backend URL into:
+Fill the ClawGUI-Server API backend URL into:
 
 ```
 examples/env_server/realdevice_server.txt

--- a/clawgui-rl/README_zh.md
+++ b/clawgui-rl/README_zh.md
@@ -117,6 +117,8 @@ git clone https://github.com/sugarandgugu/ClawGUI-Server
 2. **拉取 Docker 镜像** — 按照文档拉取 MobileWorld Android 模拟器镜像。
 3. **启动 Docker 容器** — 启动一个或多个容器，每个容器会提供一个后端 API URL（如 `http://127.0.0.1:PORT`）。
 
+> **提示**：如需让容器使用上游 [MobileWorld](https://github.com/Tongyi-MAI/MobileWorld) 最新源码（无需重新构建镜像），可在启动容器时加 `--mount-src-path /path/to/MobileWorld/src`，详见 ClawGUI-Server README。
+
 #### 第 3 步 — 注册环境 URL
 
 将容器后端 URL 逐行填入：


### PR DESCRIPTION
## Description

This is the **downstream half of a two-PR change** that lets ClawGUI-RL users iterate on MobileWorld environment fixes without rebuilding the Docker image.

### Upstream half (already submitted)

[sugarandgugu/ClawGUI-Server](https://github.com/sugarandgugu/ClawGUI-Server) — adds a new `--mount-src-path` flag to the `mw env run` CLI:

```bash
# Mount upstream MobileWorld source straight into the container
mw env run --count 1 --mount-src-path /path/to/MobileWorld/src
```

The existing `--mount-src` flag walks up `cwd` to find a `pyproject.toml` and mounts `<root>/src` — which works inside the MobileWorld repo, but in ClawGUI-Server (which vendors a snapshot of `mobile_world/`) it ends up mounting the stale local copy instead of the live upstream one. `--mount-src-path` takes an explicit host path and overrides the auto-detection. Pure additive change to ClawGUI-Server: `+90 / -0` lines, original `--mount-src` and `--dev` behavior untouched. Validated end-to-end with `mw env run --dry-run` (correct `-v <path>:/app/service/src` in the resulting `docker run`) and negative cases (non-existent path / file-not-directory both exit 1).

### This PR (clawgui-rl docs)

Two small docs touch-ups in `clawgui-rl/` to surface the new flag and clean up some leftover naming:

1. **Naming consistency** — the English README still referenced the old `OpenGUI-Server` name in 5 places. The Chinese README and the rest of the repo are already on `ClawGUI-Server`, so this brings them in line.
2. **`--mount-src-path` usage tip** — one-line tip in both EN/ZH Quick Start sections so users iterating on env bugs during RL training know they can pull upstream fixes without a docker rebuild.

Pure docs change here; no code touched in this repo.

> Note: this PR depends on the ClawGUI-Server PR landing first. Happy to wait, or to split the rename portion off if you'd rather not block on it.

Fixes # <!-- N/A -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] New model support (ClawGUI-Eval)
- [ ] New environment support (ClawGUI-RL)
- [x] Documentation update
- [ ] Refactor / code quality
- [ ] Other: <!-- describe -->

## Module(s) Affected

- [ ] `clawgui-agent`
- [ ] `clawgui-eval`
- [x] `clawgui-rl`
- [ ] Root / docs

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the existing style of the module I'm modifying
- [x] I have tested my changes locally
- [x] I have updated documentation / README where relevant
- [ ] For **ClawGUI-Eval**: <!-- N/A: docs-only change in clawgui-rl -->
- [ ] For **ClawGUI-RL**: <!-- N/A: pure README change, no code path affected -->

## Testing

**This PR (docs):**

- `grep -n "OpenGUI-Server" clawgui-rl/README.md` returns no matches after edit (was 5 before).
- New tip block renders correctly as a Markdown blockquote in both `README.md` and `README_zh.md`.
- Internal link to `Tongyi-MAI/MobileWorld` resolves.

**Companion ClawGUI-Server PR (the actual feature this tip references):**

| Case | Command | Expected | Result |
|---|---|---|---|
| explicit absolute path | `--mount-src-path /home/me/MobileWorld/src --dry-run` | `docker run ... -v /home/me/MobileWorld/src:/app/service/src` | OK |
| relative path | `--mount-src-path ./src --dry-run` | resolved to absolute, mounted correctly | OK |
| non-existent path | `--mount-src-path /tmp/nope-xyz` | red Error panel, exit 1 | OK (exit=1) |
| file (not dir) | `--mount-src-path /etc/hostname` | red Error panel, exit 1 | OK (exit=1) |
| original `--mount-src` (no path) | unchanged | identical to upstream behavior | OK |
| original `--dev` | unchanged | identical to upstream behavior | OK |
| both flags given | `--mount-src --mount-src-path /MW/src` | explicit path wins in final `-v` | OK |

## Additional Notes

- The companion ClawGUI-Server change is intentionally a **pure-additive diff** (no lines removed, no existing branch refactored) so the original `--mount-src` / `--dev` code paths are byte-identical to before. Easy to review, low merge-conflict risk.
- `.gitignore` in this repo still has a stale `OpenGUI-Server` entry (line 71); left alone here since it may still match other contributors' working copies. Happy to include it if desired.
- If the maintainer prefers the rename + tip to land separately, I can split this into two commits or two PRs.
