### PR TITLE
fix(agent): install main module and gradio for CLI and Web UI

### DIFF
--- a/clawgui-agent/setup.py
+++ b/clawgui-agent/setup.py
@@ -14,8 +14,9 @@ setup(
     description="AI-powered phone automation framework",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    url="https://github.com/yourusername/phone-agent",
+    url="https://github.com/ZJU-REAL/ClawGUI/tree/master/clawgui-agent",
     packages=find_packages(),
+    py_modules=["main"],
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Developers",
@@ -32,6 +33,7 @@ setup(
     install_requires=[
         "Pillow>=12.0.0",
         "openai>=2.9.0",
+        "gradio>=4.0.0",
     ],
     extras_require={
         "dev": [


### PR DESCRIPTION
## Description

Fixes two packaging issues in `clawgui-agent/setup.py` that break the default README install path (`uv pip install -e .`):

1. **`phone-agent` CLI fails** with `ModuleNotFoundError: No module named 'main'` because `main.py` was not installed as a module while the console entry point references `main:main`.
2. **`python webui.py` fails** with `ModuleNotFoundError: No module named 'gradio'` because `gradio` is listed in `requirements.txt` but not in `setup.py` `install_requires`, and the README install steps only run `pip install -e .`.

Changes:
- Add `py_modules=["main"]` so the `phone-agent` console script works after install.
- Add `gradio>=4.0.0` to `install_requires` so Web UI works without a separate `requirements.txt` install step.
- Update the package URL to point at the ClawGUI repository.

Fixes # <!-- N/A — discovered during local install verification -->

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] New model support (ClawGUI-Eval)
- [ ] New environment support (ClawGUI-RL)
- [ ] Documentation update
- [ ] Refactor / code quality
- [ ] Other:

## Module(s) Affected

- [x] `clawgui-agent`
- [ ] `clawgui-eval`
- [ ] `clawgui-rl`
- [ ] Root / docs

## Checklist

- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the existing style of the module I'm modifying
- [x] I have tested my changes locally
- [ ] I have updated documentation / README where relevant
- [ ] For **ClawGUI-Eval**: I have added the model to the supported model table and provided reproduction results (or noted they are pending)
- [ ] For **ClawGUI-RL**: I have verified training runs to completion without error on at least one environment

## Testing

Verified in a clean virtual environment using only the README install path:

```bash
cd clawgui-agent
uv venv .venv --python 3.12
source .venv/bin/activate
uv pip install -e .
phone-agent --help      # previously: ModuleNotFoundError: No module named 'main'
python webui.py --help  # previously: ModuleNotFoundError: No module named 'gradio'
python main.py --help   # still works
```

Also confirmed the bugs reproduce on the current upstream commit (`d990d3e`) before this patch.

## Additional Notes

- `python main.py` remains the documented primary CLI path in README; this patch makes the registered `phone-agent` console script work as intended.
- No new top-level dependencies beyond what `requirements.txt` already declared for Web UI usage.